### PR TITLE
Add some better handling of field keys from field names

### DIFF
--- a/models/config_test.go
+++ b/models/config_test.go
@@ -206,30 +206,3 @@ func TestLoadConfig(t *testing.T) {
 		}
 	}
 }
-
-func TestFieldKeyValue(t *testing.T) {
-	ds := Dataset{
-		Fields: []Field{
-			{
-				Key:  "customKey",
-				Name: "Percent Complete",
-				Type: PercentageType,
-			},
-			{
-				Name: "Total Cost",
-				Type: MoneyType,
-			},
-		},
-	}
-
-	customKey := "customKey"
-	normalKey := "total_cost"
-
-	if key := ds.Fields[0].KeyValue(); key != customKey {
-		t.Errorf("Expected keyvalue '%s' but got '%s'", customKey, key)
-	}
-
-	if key := ds.Fields[1].KeyValue(); key != normalKey {
-		t.Errorf("Expected keyvalue '%s' but got '%s'", normalKey, key)
-	}
-}


### PR DESCRIPTION
So the that config is as minimal as possible and the user doesn't need to worry about field keys we generate these in the background from the name, by underscoring any spaces.

However there could be cases whereby someone might have Total Cost's that would be an invalid field id. So we now have a regex to strip all none alphanumeric characters (excluding whitespace) then convert whitespace to underscore.

We also validate if any of the field keys would be duplicate to prevent unexpected server errors of duplicate field keys then notify the user to make the field name more unique as the following would clash for example;

Total Cost's
Total C.o.s.t.s

This doesn't validate the length or prefix the field id - for now lets leave the server to do that validate, I expect it will be rare, that someone will put a one or two character field name.