### PR TITLE
Support interpolated values in the config to pull from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Where `config.yml` is the name of your config file. Once you see confirmation th
 
 ## Building your config file
 
+Here's what an example config file looks like:
+
 ```yaml
 geckoboard_api_key: your_api_key
 database:
@@ -62,6 +64,14 @@ datasets:
       name: Conversion rate
     - type: string
       name: Source
+```
+
+#### Environment variables
+
+If you wish, you can provide any of `geckoboard_api_key`, `host`, `port`, `username`, `password` and (database) `name` as environment variables with the syntax `"{{ YOUR_CUSTOM_ENV }}"`. Make sure to keep the quotes in there! For example:
+
+```yaml
+geckoboard_api_key: "{{ GB_API_KEY }}"
 ```
 
 ### geckoboard_api_key

--- a/models/fixtures/valid_config_all_envs.yml
+++ b/models/fixtures/valid_config_all_envs.yml
@@ -1,0 +1,19 @@
+---
+geckoboard_api_key: "{{ TEST_API_KEY }}"
+database:
+ driver: postgres
+ username: "{{TEST_DB_USER}}"
+ password: "{{  TEST_DB_PASS  }}"
+ host: "{{TEST_DB_HOST }}"
+ port: "{{ TEST_DB_PORT }}"
+ name: "{{ TEST_DB_NAME}}"
+ tls_config:
+   ssl_mode: "verify-full"
+refresh_time_sec: 60
+datasets:
+ - name: some.number
+   update_type: replace
+   sql: SELECT 124
+   fields:
+     - type: 'number'
+       name: "count"

--- a/models/fixtures/valid_config_with_missing_envs.yml
+++ b/models/fixtures/valid_config_with_missing_envs.yml
@@ -1,0 +1,17 @@
+---
+geckoboard_api_key: "{{ NOT_EXISING_KEY }}"
+database:
+ driver: postgres
+ username: "{{ AGAIN INVALID }}"
+ password: "{{ NOT-VALID }}"
+ host: "{{ }}"
+ protocol: "unix"
+ name: "{{ INVAL^&ID }}"
+refresh_time_sec: 60
+datasets:
+ - name: some.number
+   update_type: replace
+   sql: SELECT 124
+   fields:
+     - type: 'number'
+       name: "count"


### PR DESCRIPTION
This is so that precious information which might already be set as environment variables can retrieved from env vars specified by the user in the config with the following syntax "{{ SOME_ENV }}"

Although windows doesn't conform to IEEE Std 1003.1-2001 and can support many more characters including spaces this for now enforces strict format