### PR TITLE
Fix file descriptor leak calling sql.Open for each query

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -241,9 +241,15 @@ func TestEndToEndFlow(t *testing.T) {
 		}))
 
 		client := NewClient("fakeKey")
+		dc := tc.config.DatabaseConfig
+		db, err := newDBConnection(dc.Driver, dc.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		gbHost = gbWS.URL
 
-		bol := processAllDatasets(&tc.config, client)
+		bol := processAllDatasets(&tc.config, client, db)
 
 		if tc.expectError != bol {
 			t.Errorf("[%d] Expected hasErrors to be %t but got %t", i, tc.expectError, bol)

--- a/models/sql.go
+++ b/models/sql.go
@@ -20,9 +20,9 @@ type DatasetRows []map[string]interface{}
 
 // BuildDataset calls queryDatasource to query the datasource for a
 // dataset entry and builds up a slice of rows ready for processing by the client
-func (ds Dataset) BuildDataset(dc *DatabaseConfig) (DatasetRows, error) {
+func (ds Dataset) BuildDataset(dc *DatabaseConfig, db *sql.DB) (DatasetRows, error) {
 	var datasetRecs DatasetRows
-	recs, err := ds.queryDatasource(dc)
+	recs, err := ds.queryDatasource(dc, db)
 
 	if err != nil {
 		return nil, err
@@ -63,12 +63,7 @@ func (ds Dataset) BuildDataset(dc *DatabaseConfig) (DatasetRows, error) {
 	return datasetRecs, nil
 }
 
-func (ds Dataset) queryDatasource(dc *DatabaseConfig) (records []interface{}, err error) {
-	db, err := sql.Open(dc.Driver, dc.URL)
-	if err != nil {
-		return nil, fmt.Errorf("Database open failed: %s", err)
-	}
-
+func (ds Dataset) queryDatasource(dc *DatabaseConfig, db *sql.DB) (records []interface{}, err error) {
 	rows, err := db.Query(ds.SQL)
 
 	if err != nil {

--- a/models/sql_test.go
+++ b/models/sql_test.go
@@ -418,7 +418,8 @@ func TestBuildDatasetSQLiteDriver(t *testing.T) {
 	}
 
 	for idx, tc := range testCases {
-		out, err := tc.config.Datasets[0].BuildDataset(tc.config.DatabaseConfig)
+		db := NewDBConnection(t, tc.config.DatabaseConfig.Driver, tc.config.DatabaseConfig.URL)
+		out, err := tc.config.Datasets[0].BuildDataset(tc.config.DatabaseConfig, db)
 
 		if tc.err == "" && err != nil {
 			t.Errorf("[%d] Expected no error but got %s", idx, err)
@@ -850,7 +851,8 @@ func TestBuildDatasetPostgresDriver(t *testing.T) {
 	}
 
 	for idx, tc := range testCases {
-		out, err := tc.config.Datasets[0].BuildDataset(tc.config.DatabaseConfig)
+		db := NewDBConnection(t, tc.config.DatabaseConfig.Driver, tc.config.DatabaseConfig.URL)
+		out, err := tc.config.Datasets[0].BuildDataset(tc.config.DatabaseConfig, db)
 
 		if tc.err == "" && err != nil {
 			t.Errorf("[%d] Expected no error but got %s", idx, err)
@@ -1282,7 +1284,8 @@ func TestBuildDatasetMySQLDriver(t *testing.T) {
 	}
 
 	for idx, tc := range testCases {
-		out, err := tc.config.Datasets[0].BuildDataset(tc.config.DatabaseConfig)
+		db := NewDBConnection(t, tc.config.DatabaseConfig.Driver, tc.config.DatabaseConfig.URL)
+		out, err := tc.config.Datasets[0].BuildDataset(tc.config.DatabaseConfig, db)
 
 		if tc.err == "" && err != nil {
 			t.Errorf("[%d] Expected no error but got %s", idx, err)
@@ -1317,4 +1320,14 @@ func parseTime(str string, t *testing.T) time.Time {
 
 	return tme
 
+}
+
+func NewDBConnection(t *testing.T, driver, url string) *sql.DB {
+	pool, err := sql.Open(driver, url)
+
+	if err != nil {
+		t.Fatalf("Database open failed: %s", err)
+	}
+
+	return pool
 }


### PR DESCRIPTION
queryDatasource was incorrectly opening new connection pool for every
datasource query but never closing any of them. sql.Open should be a long-lived connection and this commit changes that so that a pool is created on first start up and passed around.

On program exit any opening sockets from the connection pool should be cleaned up by the kernel. This also limits the max connections to just 5. As this processes the queries sequentially this should be more than enough and only 1 should only ever be open.