### PR TITLE
Pull docker images for all rdbms, setup db/user and run tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,45 @@
 BUILD_DIR=builds
 VERSION=0.2.0
 GIT_SHA=$(shell git rev-parse --short HEAD)
+PASSWORD=root
+MSPASS=zebra-IT-32
+
+DOCKER_MYSQL=mysql/mysql-server:5.7
+DOCKER_POSTGRES=postgres:9.6
+DOCKER_MSSQL=microsoft/mssql-server-linux
+DB_NAME=testdb
 
 build:
-	mkdir -p $(BUILD_DIR)
+	mkdir -p $(BUILD_DIR) 
 	docker pull karalabe/xgo-latest
 	go get github.com/karalabe/xgo
 	xgo -dest=$(BUILD_DIR) \
 	-ldflags="-X main.version=$(VERSION) -X main.gitSHA=$(GIT_SHA)" \
 	-targets="darwin-10.10/* windows-8.0/amd64 windows-8.0/386 linux/amd64 linux/386" .
 
+pull-docker-images:
+	docker pull ${DOCKER_MYSQL}
+	docker pull ${DOCKER_POSTGRES}
+	docker pull ${DOCKER_MSSQL}
+
+run-containers:
+	docker rm -f sd-mysql sd-postgres sd-mssql || true
+	docker run --name sd-mysql -e MYSQL_ROOT_PASSWORD=${PASSWORD} -p 3306:3306 -d ${DOCKER_MYSQL} || true
+	docker run --name sd-postgres -e POSTGRES_PASSWORD=${PASSWORD} -p 5432:5432 -d ${DOCKER_POSTGRES} || true
+	docker run --name sd-mssql -e ACCEPT_EULA=Y -e SA_PASSWORD=${MSPASS} -p 1433:1433 -d ${DOCKER_MSSQL} || true
+
+setup-db:
+	# Mysql ensure root can access from anywhere
+	docker exec -it sd-mysql mysql -uroot -proot -e "CREATE USER 'root'@'%' IDENTIFIED BY '${PASSWORD}'" || true
+	docker exec -it sd-mysql mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%'" || true
+	docker exec -it sd-mysql mysql -uroot -proot -e "CREATE DATABASE ${DB_NAME};" || true
+	# Postgres db creation
+	docker exec --user postgres -it sd-postgres psql -c "CREATE DATABASE ${DB_NAME}" || true
+	# MSSQL db creation
+	docker exec -it sd-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${MSPASS} -Q "CREATE DATABASE testdb" || true
+
 test:
-	MYSQL_URL=root@/testdb?parseTime=true POSTGRES_URL=postgres://postgres@localhost:5432/testdb?sslmode=disable go test ./... -v
+	MYSQL_URL=root:${PASSWORD}@/testdb?parseTime=true \
+	POSTGRES_URL=postgres://postgres:${PASSWORD}@localhost:5432/testdb?sslmode=disable \
+	MSSQL_URL="odbc:server=localhost;port=1433;user id=sa;password=${MSPASS};database=${DB_NAME}" \
+	go test ./... -v | grep -v 'vendor'

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ pull-docker-images:
 
 run-containers:
 	docker rm -f sd-mysql sd-postgres sd-mssql || true
-	docker run --name sd-mysql -e MYSQL_ROOT_PASSWORD=${PASSWORD} -p 3306:3306 -d ${DOCKER_MYSQL} || true
-	docker run --name sd-postgres -e POSTGRES_PASSWORD=${PASSWORD} -p 5432:5432 -d ${DOCKER_POSTGRES} || true
+	docker run --name sd-mysql -e MYSQL_ROOT_PASSWORD=${PASSWORD} -p 3307:3306 -d ${DOCKER_MYSQL} || true
+	docker run --name sd-postgres -e POSTGRES_PASSWORD=${PASSWORD} -p 5433:5432 -d ${DOCKER_POSTGRES} || true
 	docker run --name sd-mssql -e ACCEPT_EULA=Y -e SA_PASSWORD=${MSPASS} -p 1433:1433 -d ${DOCKER_MSSQL} || true
 
 setup-db:
@@ -39,7 +39,7 @@ setup-db:
 	docker exec -it sd-mssql /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P ${MSPASS} -Q "CREATE DATABASE testdb" || true
 
 test:
-	MYSQL_URL=root:${PASSWORD}@/testdb?parseTime=true \
-	POSTGRES_URL=postgres://postgres:${PASSWORD}@localhost:5432/testdb?sslmode=disable \
+	MYSQL_URL="root:${PASSWORD}@tcp(localhost:3307)/testdb?parseTime=true" \
+	POSTGRES_URL=postgres://postgres:${PASSWORD}@localhost:5433/testdb?sslmode=disable \
 	MSSQL_URL="odbc:server=localhost;port=1433;user id=sa;password=${MSPASS};database=${DB_NAME}" \
 	go test ./... -v | grep -v 'vendor'

--- a/models/sql_test.go
+++ b/models/sql_test.go
@@ -479,7 +479,7 @@ func TestBuildDatasetPostgresDriver(t *testing.T) {
 				RefreshTimeSec:   120,
 				DatabaseConfig: &DatabaseConfig{
 					Driver: PostgresDriver,
-					URL:    "postgres://postgresql:postgres@fakehost:5432",
+					URL:    "postgres://postgresql:postgres@127.0.0.1:9999",
 				},
 				Datasets: []Dataset{
 					{
@@ -494,7 +494,7 @@ func TestBuildDatasetPostgresDriver(t *testing.T) {
 				},
 			},
 			out: nil,
-			err: "Database query failed: dial tcp: lookup fakehost: no such host",
+			err: "Database query failed: dial tcp 127.0.0.1:9999: getsockopt: connection refused",
 		},
 		{
 			config: Config{
@@ -912,7 +912,7 @@ func TestBuildDatasetMySQLDriver(t *testing.T) {
 				RefreshTimeSec:   120,
 				DatabaseConfig: &DatabaseConfig{
 					Driver: MySQLDriver,
-					URL:    "root@tcp(fakehost:3306)/testdb",
+					URL:    "root@tcp(127.0.0.1:9999)/testdb",
 				},
 				Datasets: []Dataset{
 					{
@@ -927,7 +927,7 @@ func TestBuildDatasetMySQLDriver(t *testing.T) {
 				},
 			},
 			out: nil,
-			err: "Database query failed: dial tcp: lookup fakehost: no such host",
+			err: "Database query failed: dial tcp 127.0.0.1:9999: getsockopt: connection refused",
 		},
 		{
 			config: Config{


### PR DESCRIPTION
Before this was manually hand managed and is really a time waster
This pulls the relevant db docker images and execs some queries to
create the dbs for the tests.

make pull-docker-images run-containers
make setup-db test

So much easier and cleaner for others

This also makes it really easy for mssql because that required for initial setup and is only a trial - so using the docker image will be good

Nothing is persisted once shutdown and that is fine as the tests setup all data required before hand.