### PR TITLE
Fix bug whereby no sql row sent invalid data payload Geckoboard

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -292,6 +292,25 @@ func TestSendAllData(t *testing.T) {
 			err: errUnexpectedResponse.Error(),
 		},
 		{
+			//Replace dataset with no data
+			dataset: models.Dataset{
+				Name:       "app.no.data",
+				UpdateType: models.Replace,
+				Fields: []models.Field{
+					{Name: "App", Type: models.StringType},
+					{Name: "Percent", Type: models.PercentageType},
+				},
+			},
+			data: models.DatasetRows{},
+			requests: []request{
+				{
+					Method: http.MethodPut,
+					Path:   "/datasets/app.no.data/data",
+					Body:   `{"data":[]}`,
+				},
+			},
+		},
+		{
 			//Replace dataset under the batch rows limit doesn't error
 			dataset: models.Dataset{
 				Name:       "app.reliable.percent",
@@ -322,6 +341,19 @@ func TestSendAllData(t *testing.T) {
 					Body:   `{"data":[{"app":"acceptance","percent":0.43},{"app":"redis","percent":0.22},{"app":"api","percent":0.66}]}`,
 				},
 			},
+		},
+		{
+			//Append with no data makes no requests
+			dataset: models.Dataset{
+				Name:       "append.no.data",
+				UpdateType: models.Append,
+				Fields: []models.Field{
+					{Name: "App", Type: models.StringType},
+					{Name: "Count", Type: models.NumberType},
+				},
+			},
+			data:     models.DatasetRows{},
+			requests: []request{},
 		},
 		{
 			//Append dataset under the batch rows limit

--- a/integration_test.go
+++ b/integration_test.go
@@ -205,6 +205,36 @@ func TestEndToEndFlow(t *testing.T) {
 				},
 			},
 		},
+		{
+			// No data rows retrieved - so should send {'data': []} when type replace
+			config: models.Config{
+				DatabaseConfig: &models.DatabaseConfig{
+					Driver: models.SQLiteDriver,
+					URL:    filepath.Join("models", "fixtures", "db.sqlite"),
+				},
+				Datasets: []models.Dataset{
+					{
+						Name:       "empty.sql.rows",
+						SQL:        `SELECT "test", null FROM builds WHERE id < 0`,
+						UpdateType: models.Replace,
+						Fields: []models.Field{
+							{Name: "App", Type: models.StringType},
+							{Name: "Build Count", Type: models.NumberType, Optional: true},
+						},
+					},
+				},
+			},
+			gbReqs: []GBRequest{
+				{
+					Path: "/datasets/empty.sql.rows",
+					Body: `{"id":"empty.sql.rows","fields":{"app":{"type":"string","name":"App"},"build_count":{"type":"number","name":"Build Count","optional":true}}}`,
+				},
+				{
+					Path: "/datasets/empty.sql.rows/data",
+					Body: `{"data":[]}`,
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {

--- a/models/sql.go
+++ b/models/sql.go
@@ -7,10 +7,10 @@ import (
 
 	"gopkg.in/guregu/null.v3"
 
+	_ "github.com/denisenkom/go-mssqldb"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
-	_ "github.com/denisenkom/go-mssqldb"
 )
 
 const dateFormat = "2006-01-02"
@@ -22,7 +22,7 @@ type DatasetRows []map[string]interface{}
 // BuildDataset calls queryDatasource to query the datasource for a
 // dataset entry and builds up a slice of rows ready for processing by the client
 func (ds Dataset) BuildDataset(dc *DatabaseConfig, db *sql.DB) (DatasetRows, error) {
-	var datasetRecs DatasetRows
+	datasetRecs := DatasetRows{}
 	recs, err := ds.queryDatasource(dc, db)
 
 	if err != nil {

--- a/models/sql_test.go
+++ b/models/sql_test.go
@@ -415,6 +415,25 @@ func TestBuildDatasetSQLiteDriver(t *testing.T) {
 				},
 			},
 		},
+		{
+			// No rows returns empty slice
+			config: Config{
+				DatabaseConfig: &DatabaseConfig{
+					Driver: SQLiteDriver,
+					URL:    "fixtures/db.sqlite",
+				},
+				Datasets: []Dataset{
+					{
+						SQL: `SELECT "test", null FROM builds WHERE id < 0`,
+						Fields: []Field{
+							{Name: "App", Type: StringType},
+							{Name: "Run time", Type: NumberType, Optional: true},
+						},
+					},
+				},
+			},
+			out: DatasetRows{},
+		},
 	}
 
 	for idx, tc := range testCases {
@@ -427,6 +446,10 @@ func TestBuildDatasetSQLiteDriver(t *testing.T) {
 
 		if err != nil && tc.err != err.Error() {
 			t.Errorf("[%d] Expected error %s but got %s", idx, tc.err, err)
+		}
+
+		if err == nil && out == nil {
+			t.Errorf("expected slice to be initialized when no error but wasn't")
 		}
 
 		if len(out) != len(tc.out) {
@@ -828,12 +851,12 @@ func TestBuildDatasetPostgresDriver(t *testing.T) {
 			//NumberType as optional and is null returns null
 			config: Config{
 				DatabaseConfig: &DatabaseConfig{
-					Driver: SQLiteDriver,
-					URL:    "fixtures/db.sqlite",
+					Driver: PostgresDriver,
+					URL:    env,
 				},
 				Datasets: []Dataset{
 					{
-						SQL: `SELECT "test", null FROM builds limit 1`,
+						SQL: `SELECT 'test', null FROM builds limit 1`,
 						Fields: []Field{
 							{Name: "App", Type: StringType},
 							{Name: "Run time", Type: NumberType, Optional: true},
@@ -848,6 +871,25 @@ func TestBuildDatasetPostgresDriver(t *testing.T) {
 				},
 			},
 		},
+		{
+			// No rows returns empty slice
+			config: Config{
+				DatabaseConfig: &DatabaseConfig{
+					Driver: PostgresDriver,
+					URL:    env,
+				},
+				Datasets: []Dataset{
+					{
+						SQL: `SELECT 'test', null FROM builds WHERE id < 0`,
+						Fields: []Field{
+							{Name: "App", Type: StringType},
+							{Name: "Run time", Type: NumberType, Optional: true},
+						},
+					},
+				},
+			},
+			out: DatasetRows{},
+		},
 	}
 
 	for idx, tc := range testCases {
@@ -860,6 +902,10 @@ func TestBuildDatasetPostgresDriver(t *testing.T) {
 
 		if err != nil && tc.err != err.Error() {
 			t.Errorf("[%d] Expected error %s but got %s", idx, tc.err, err)
+		}
+
+		if err == nil && out == nil {
+			t.Errorf("expected slice to be initialized when no error but wasn't")
 		}
 
 		if len(out) != len(tc.out) {
@@ -1261,8 +1307,8 @@ func TestBuildDatasetMySQLDriver(t *testing.T) {
 			//NumberType as optional and is null returns null
 			config: Config{
 				DatabaseConfig: &DatabaseConfig{
-					Driver: SQLiteDriver,
-					URL:    "fixtures/db.sqlite",
+					Driver: MySQLDriver,
+					URL:    env,
 				},
 				Datasets: []Dataset{
 					{
@@ -1281,6 +1327,25 @@ func TestBuildDatasetMySQLDriver(t *testing.T) {
 				},
 			},
 		},
+		{
+			// No rows returns empty slice
+			config: Config{
+				DatabaseConfig: &DatabaseConfig{
+					Driver: MySQLDriver,
+					URL:    env,
+				},
+				Datasets: []Dataset{
+					{
+						SQL: `SELECT "test", null FROM builds WHERE id < 0`,
+						Fields: []Field{
+							{Name: "App", Type: StringType},
+							{Name: "Run time", Type: NumberType, Optional: true},
+						},
+					},
+				},
+			},
+			out: DatasetRows{},
+		},
 	}
 
 	for idx, tc := range testCases {
@@ -1293,6 +1358,10 @@ func TestBuildDatasetMySQLDriver(t *testing.T) {
 
 		if err != nil && tc.err != err.Error() {
 			t.Errorf("[%d] Expected error %s but got %s", idx, tc.err, err)
+		}
+
+		if err == nil && out == nil {
+			t.Errorf("expected slice to be initialized when no error but wasn't")
 		}
 
 		if len(out) != len(tc.out) {
@@ -1713,6 +1782,25 @@ func TestBuildDatasetMSSQLDriver(t *testing.T) {
 				},
 			},
 		},
+		{
+			// No rows returns empty slice
+			config: Config{
+				DatabaseConfig: &DatabaseConfig{
+					Driver: MSSQLDriver,
+					URL:    env,
+				},
+				Datasets: []Dataset{
+					{
+						SQL: `SELECT 'test', null FROM builds WHERE id < 0`,
+						Fields: []Field{
+							{Name: "App", Type: StringType},
+							{Name: "Run time", Type: NumberType, Optional: true},
+						},
+					},
+				},
+			},
+			out: DatasetRows{},
+		},
 	}
 
 	for idx, tc := range testCases {
@@ -1727,8 +1815,11 @@ func TestBuildDatasetMSSQLDriver(t *testing.T) {
 			t.Errorf("[%d] Expected error %s but got %s", idx, tc.err, err)
 		}
 
+		if err != nil && tc.err != err.Error() {
+			t.Errorf("[%d] Expected error %s but got %s", idx, tc.err, err)
+		}
+
 		if len(out) != len(tc.out) {
-			fmt.Printf("%#v\n", out)
 			t.Errorf("[%d] Expected slice size %d but got %d", idx, len(tc.out), len(out))
 			continue
 		}


### PR DESCRIPTION
Before we were sending `{"data": null}` Geckoboard complains about this, but there are situations you might want to wipe the current data with no new data on a dataset.

For type replace datasets it correctly sends `{"data": []}` and for type append doesn't make any request at all as it doesn't need to as it isn't wiping the existing data.