### PR TITLE
Support updating the unique by to match generated field keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,7 +52,10 @@ func NewClient(apiKey string) *Client {
 }
 
 func (c *Client) FindOrCreateDataset(ds *models.Dataset) error {
-	ds.BuildSchemaFields()
+	if err := ds.BuildSchemaFields(); err != nil {
+		return err
+	}
+
 	resp, err := c.makeRequest(http.MethodPut, fmt.Sprintf("/datasets/%s", ds.Name), ds)
 
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -156,7 +156,7 @@ func TestEndToEndFlow(t *testing.T) {
 						Name:       "app.counts",
 						SQL:        "SELECT app_name, count(*) FROM builds GROUP BY app_name order by app_name",
 						UpdateType: models.Append,
-						UniqueBy:   []string{"app_name"},
+						UniqueBy:   []string{"app"},
 						Fields: []models.Field{
 							{Name: "App", Type: models.StringType},
 							{Name: "Build Count", Type: models.NumberType},
@@ -167,13 +167,36 @@ func TestEndToEndFlow(t *testing.T) {
 			gbReqs: []GBRequest{
 				{
 					Path: "/datasets/app.counts",
-					Body: `{"id":"app.counts","unique_by":["app_name"],"fields":{"app":{"type":"string","name":"App"},"build_count":{"type":"number","name":"Build Count"}}}`,
+					Body: `{"id":"app.counts","unique_by":["app"],"fields":{"app":{"type":"string","name":"App"},"build_count":{"type":"number","name":"Build Count"}}}`,
 				},
 				{
 					Path: "/datasets/app.counts/data",
 					Body: `{"data":[{"app":"","build_count":2},{"app":"everdeen","build_count":2},{"app":"geckoboard-ruby","build_count":3},{"app":"react","build_count":1},{"app":"westworld","build_count":1}]}`,
 				},
 			},
+		},
+		{
+			// Unique by without a matching field errors makes no requests
+			config: models.Config{
+				DatabaseConfig: &models.DatabaseConfig{
+					Driver: models.SQLiteDriver,
+					URL:    filepath.Join("models", "fixtures", "db.sqlite"),
+				},
+				Datasets: []models.Dataset{
+					{
+						Name:       "app.counts",
+						SQL:        "SELECT app_name, count(*) FROM builds GROUP BY app_name order by app_name",
+						UpdateType: models.Append,
+						UniqueBy:   []string{"app_name"},
+						Fields: []models.Field{
+							{Name: "App", Type: models.StringType},
+							{Name: "Build Count", Type: models.NumberType},
+						},
+					},
+				},
+			},
+			gbReqs:      []GBRequest{},
+			expectError: true,
 		},
 		{
 			// Optional field correctly sent as null

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func processAllDatasets(config *models.Config, client *Client, db *sql.DB) (hasE
 }
 
 func printErrorMsg(name string, err error) {
-	fmt.Printf("There was an error while trying to update %s: %s", name, err)
+	fmt.Printf("There was an error while trying to update %s: %s\n", name, err)
 }
 
 func newDBConnection(driver, url string) (*sql.DB, error) {

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -6,6 +6,274 @@ import (
 	"testing"
 )
 
+func TestBuildSchemaFields(t *testing.T) {
+	testCases := []struct {
+		in  *Dataset
+		out *Dataset
+		err string
+	}{
+		{
+			// Field name unaltered
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "count",
+						Type: "datetime",
+					},
+				},
+			},
+			out: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "count",
+						Type: "datetime",
+					},
+				},
+				SchemaFields: map[string]Field{
+					"count": Field{
+						Name: "count",
+						Type: "datetime",
+					},
+				},
+			},
+		},
+		{
+			// Field has key provided
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "Count All",
+						Key:  "not_matching",
+						Type: "datetime",
+					},
+				},
+			},
+			out: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "Count All",
+						Key:  "not_matching",
+						Type: "datetime",
+					},
+				},
+				SchemaFields: map[string]Field{
+					"not_matching": Field{
+						Name: "Count All",
+						Key:  "not_matching",
+						Type: "datetime",
+					},
+				},
+			},
+		},
+		{
+			// Multiple fields
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "Count All",
+						Type: "datetime",
+					},
+					{
+						Name: "Service",
+						Key:  "newkey",
+						Type: "string",
+					},
+				},
+			},
+			out: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "Count All",
+						Type: "datetime",
+					},
+					{
+						Name: "Service",
+						Key:  "newkey",
+						Type: "string",
+					},
+				},
+				SchemaFields: map[string]Field{
+					"count_all": Field{
+						Name: "Count All",
+						Type: "datetime",
+					},
+					"newkey": {
+						Name: "Service",
+						Key:  "newkey",
+						Type: "string",
+					},
+				},
+			},
+		},
+		{
+			// Unique not matching any fields
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "count",
+						Type: "datetime",
+					},
+				},
+				UniqueBy: []string{"count", "blah"},
+			},
+			out: &Dataset{},
+			err: "Following unique by 'blah' for dataset 'users.count' has no matching field",
+		},
+		{
+			// Unique by errors when the user doesn't use custom key supplied
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "App name",
+						Key:  "name_of_appy",
+						Type: "string",
+					},
+					{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+				UniqueBy: []string{"APP name", "Count All"},
+			},
+			out: &Dataset{},
+			err: "Following unique by 'APP name' for dataset 'users.count' has no matching field",
+		},
+		{
+			// Unique by errors with the users original input
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "App name",
+						Key:  "name_of_appy",
+						Type: "string",
+					},
+					{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+				UniqueBy: []string{"App name", "Count All"},
+			},
+			out: &Dataset{},
+			err: "Following unique by 'App name' for dataset 'users.count' has no matching field",
+		},
+		{
+			// Unique by converted correctly to match generated field keys
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "App name",
+						Type: "string",
+					},
+					{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+				UniqueBy: []string{"App name", "Count All"},
+			},
+			out: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "App name",
+						Type: "string",
+					},
+					{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+				UniqueBy: []string{"app_name", "count_all"},
+				SchemaFields: map[string]Field{
+					"app_name": Field{
+						Name: "App name",
+						Type: "string",
+					},
+					"count_all": Field{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+			},
+		},
+		{
+			// Unique by works with users supplied custom key
+			in: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "App name",
+						Key:  "name_of_appy",
+						Type: "string",
+					},
+					{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+				UniqueBy: []string{"name_of_appy", "Count All"},
+			},
+			out: &Dataset{
+				Name: "users.count",
+				Fields: []Field{
+					{
+						Name: "App name",
+						Key:  "name_of_appy",
+						Type: "string",
+					},
+					{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+				UniqueBy: []string{"name_of_appy", "count_all"},
+				SchemaFields: map[string]Field{
+					"name_of_appy": Field{
+						Name: "App name",
+						Key:  "name_of_appy",
+						Type: "string",
+					},
+					"count_all": Field{
+						Name: "Count All",
+						Type: "number",
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		err := tc.in.BuildSchemaFields()
+
+		if tc.err == "" && err != nil {
+			t.Errorf("[%d] Expected no error but got %s", i, err)
+		}
+
+		if tc.err != "" && err == nil {
+			t.Errorf("[%d] Expected error %s but got none", i, tc.err)
+		}
+
+		if err != nil && tc.err != err.Error() {
+			t.Errorf("[%d] Expected error %s but got %s", i, tc.err, err)
+		}
+
+		if tc.err == "" && !reflect.DeepEqual(tc.in, tc.out) {
+			t.Errorf("[%d] Expected dataset %#v but got %#v", i, tc.in, tc.out)
+		}
+	}
+}
+
 func TestDatasetValidate(t *testing.T) {
 	testCases := []struct {
 		dataset Dataset


### PR DESCRIPTION
This fixes the following issue raised - https://github.com/geckoboard/sql-dataset/issues/22

- PR does the following;
 - Updates the unique_by fields now to match the generated field key
 - If no match field exists for a unique by it will error