### PR TITLE
Setup circleCI for sql-datasets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test:
     machine: true
     working_directory: /home/circleci/go/src/github.com/geckoboard/sql-dataset
     environment:
@@ -28,3 +28,23 @@ jobs:
       - run: make pull-docker-images run-containers
       - run: make setup-db
       - run: make test
+  build:
+    machine: true
+    working_directory: /home/circleci/go/src/github.com/geckoboard/sql-dataset
+    environment:
+      GOPATH: "/home/circleci/go"
+    steps:
+      - run: echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+      - checkout
+      - run: make build
+      - store_artifacts:
+          path: builds
+workflows:
+  version: 2
+  test_and_build:
+    jobs:
+      - test
+      - build:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,11 @@ jobs:
       - checkout
       - run: make pull-docker-images run-containers
       - run: make setup-db
-      - run: make test
+      - run:
+          name: "Run tests and upload coverage report"
+          command: |
+            make test
+            bash <(curl -s https://codecov.io/bash)
   build:
     machine: true
     working_directory: /home/circleci/go/src/github.com/geckoboard/sql-dataset

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    working_directory: /home/circleci/go/src/github.com/geckoboard/sql-dataset
+    environment:
+      GOPATH: "/home/circleci/go"
+    steps:
+      - run: echo 'export PATH=$GOPATH/bin:$PATH' >> $BASH_ENV
+      - run:
+          name: "Install mysql client"
+          command: sudo apt install mysql-client
+      - run:
+          name: "Install postgres client tools"
+          command: |
+            # The machine executor image is old 14.04 and only supplies 9.3 we need 9.4+ for the postgres pg_isready util
+            sudo add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main"
+            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+            sudo apt-get update
+            sudo apt install postgresql-client-9.6
+      - run:
+          name: "Upgrade go to 1.10"
+          command: |
+            cd $HOME
+            curl https://dl.google.com/go/go1.10.8.linux-amd64.tar.gz -o golang.tar.gz
+            sudo tar -C /usr/local -xzf golang.tar.gz
+      - checkout
+      - run: make pull-docker-images run-containers
+      - run: make setup-db
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,13 @@ pull-docker-images:
 
 run-containers:
 	docker rm -f sd-mysql sd-postgres sd-mssql || true
-	docker run --name sd-mysql -e MYSQL_ROOT_PASSWORD=${PASSWORD} -p 3307:3306 -d ${DOCKER_MYSQL} || true
-	docker run --name sd-postgres -e POSTGRES_PASSWORD=${PASSWORD} -p 5433:5432 -d ${DOCKER_POSTGRES} || true
 	docker run --name sd-mssql -e ACCEPT_EULA=Y -e SA_PASSWORD=${MSPASS} -p 1433:1433 -d ${DOCKER_MSSQL} || true
+	# MySQL
+	docker run --name sd-mysql -e MYSQL_ROOT_PASSWORD=${PASSWORD} -p 3307:3306 -d ${DOCKER_MYSQL} || true
+	scripts/wait_for_mysql sd-mysql
+	# Postgres
+	docker run --name sd-postgres -e POSTGRES_PASSWORD=${PASSWORD} -p 5433:5432 -d ${DOCKER_POSTGRES} || true
+	scripts/wait_for_postgres 5433 ${PASSWORD}
 
 setup-db:
 	# Mysql ensure root can access from anywhere
@@ -42,4 +46,4 @@ test:
 	MYSQL_URL="root:${PASSWORD}@tcp(localhost:3307)/testdb?parseTime=true" \
 	POSTGRES_URL=postgres://postgres:${PASSWORD}@localhost:5433/testdb?sslmode=disable \
 	MSSQL_URL="odbc:server=localhost;port=1433;user id=sa;password=${MSPASS};database=${DB_NAME}" \
-	go test ./... -v | grep -v 'vendor'
+	go test ./... -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SQL-Dataset, by Geckoboard
 
+[![CircleCI](https://circleci.com/gh/geckoboard/sql-dataset.svg?style=svg)](https://circleci.com/gh/geckoboard/sql-dataset)
+
 Quickly and easily send data from Microsoft SQL Server, MySQL, Postgres and SQLite databases to Geckoboard Datasets.
 
 SQL-Dataset is a command line app that takes the hassle out of integrating your database with Geckoboard. Rather than having to work with client libraries and write a bunch of code to connect to and query your database, with SQL-Dataset all you need to do is fill out a simple config file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SQL-Dataset, by Geckoboard
 
-[![CircleCI](https://circleci.com/gh/geckoboard/sql-dataset.svg?style=svg)](https://circleci.com/gh/geckoboard/sql-dataset)
+[![CircleCI](https://circleci.com/gh/geckoboard/sql-dataset.svg?style=svg)](https://circleci.com/gh/geckoboard/sql-dataset)  [![codecov](https://codecov.io/gh/geckoboard/sql-dataset/branch/master/graph/badge.svg)](https://codecov.io/gh/geckoboard/sql-dataset)
 
 Quickly and easily send data from Microsoft SQL Server, MySQL, Postgres and SQLite databases to Geckoboard Datasets.
 

--- a/code_coverage.sh
+++ b/code_coverage.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -race -coverprofile=profile.out -covermode=atomic $d
+
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done

--- a/models/sql_test.go
+++ b/models/sql_test.go
@@ -517,7 +517,7 @@ func TestBuildDatasetPostgresDriver(t *testing.T) {
 				},
 			},
 			out: nil,
-			err: fmt.Sprintf(errFailedSQLQuery, "dial tcp 127.0.0.1:9999: getsockopt: connection refused"),
+			err: fmt.Sprintf(errFailedSQLQuery, "dial tcp 127.0.0.1:9999: connect: connection refused"),
 		},
 		{
 			config: Config{
@@ -973,7 +973,7 @@ func TestBuildDatasetMySQLDriver(t *testing.T) {
 				},
 			},
 			out: nil,
-			err: fmt.Sprintf(errFailedSQLQuery, "dial tcp 127.0.0.1:9999: getsockopt: connection refused"),
+			err: fmt.Sprintf(errFailedSQLQuery, "dial tcp 127.0.0.1:9999: connect: connection refused"),
 		},
 		{
 			config: Config{

--- a/scripts/wait_for_mysql
+++ b/scripts/wait_for_mysql
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ATTEMPTS=0
+
+until docker exec -it $1 mysql -uroot -proot -e "show databases;" -P 3306 > /dev/null 2>&1;
+do
+  COUNTER=$((COUNTER + 1))
+  echo "Waiting for mysql in docker container"
+
+  if [[ "$COUNTER" == 20 ]]; then
+    echo "MySQL still not responding after 20 attempts... Stopping"
+    exit 1
+  fi
+
+  sleep 1;
+done

--- a/scripts/wait_for_postgres
+++ b/scripts/wait_for_postgres
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Taken from https://starkandwayne.com/blog/how-to-know-when-your-postgres-service-is-ready/
+
+PG_URI="postgres://postgres:$2@localhost:$1/shield"
+ATTEMPTS=0
+
+# make sure pg is ready to accept connections
+until pg_isready -h localhost -p $1 -U postgres > /dev/null
+do
+  COUNTER=$((COUNTER + 1))
+  echo "Waiting for postgres at: $PG_URI"
+  
+  if [[ "$COUNTER" == 10 ]]; then
+    echo "PostgresDB still not responding after 10 attempts... Stopping"
+    exit 1
+  fi
+  sleep 1;
+done


### PR DESCRIPTION
As part of my handover I've finally setup circleCI for SQL-Datasets. 

To ensure that both mysql and postgreSQL are successfully running there are some bash scripts to validate otherwise it would mostly fail. The bash script is called immediately after the docker container starting for both mysql and postgreSQL.

**There will be 2 jobs that will run on CI**

1. The unit/integration tests
2. Building SQL dataset cross-platform binaries and storing in artifacts **only for master branch**

SQL-Dataset currently supports 1.10 currently in the tests but builds with go 1.8.3 (this should be upgraded at some point for sure - I've raised an issue to review upgrading this). 

We have libraries which use CGO, so when we want to build binaries cross platform this requires some host specific dependencies. We use [xgo docker and go library](https://github.com/karalabe/xgo) to help with this which has made this extremely simple.

The built binaries are stored in the artifacts which can be downloaded - probably better would be long term to create new version and upload assets 
![image](https://user-images.githubusercontent.com/4930249/57622673-087d2f00-7586-11e9-9e54-9b8ae15429c9.png)

During the handover it was discussed about adding coverage reporting for the future to ensure that the coverage isn't dropping. As this repo has never had coverage review, this has now also been added as part of this PR