### PR TITLE
Add support for duration type

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ SQL-Dataset supports all of the field types supported by the [Datasets API](http
 
 - date
 - datetime
+- duration
 - number
 - percentage
 - string
@@ -172,6 +173,16 @@ fields
  - name: MRR
    type: money
    currency_code: USD
+```
+
+The `duration` field type requires a `time_unit` to be provided:
+With a value one of: milliseconds, seconds, minutes, hours
+
+```yaml
+fields
+ - name: Time until support ticket resolved
+   type: duration
+   time_unit: minutes
 ```
 
 Numeric field types can support null values. For a field to support this, pass the `optional` key:

--- a/integration_test.go
+++ b/integration_test.go
@@ -74,6 +74,35 @@ func TestEndToEndFlow(t *testing.T) {
 			},
 		},
 		{
+			config: models.Config{
+				DatabaseConfig: &models.DatabaseConfig{
+					Driver: models.SQLiteDriver,
+					URL:    filepath.Join("models", "fixtures", "db.sqlite"),
+				},
+				Datasets: []models.Dataset{
+					{
+						Name:       "app.durations",
+						SQL:        "SELECT app_name, run_time FROM builds ORDER BY app_name",
+						UpdateType: models.Append,
+						Fields: []models.Field{
+							{Name: "App", Type: models.StringType},
+							{Name: "Build runtime", Type: models.DurationType, TimeUnit: "minutes"},
+						},
+					},
+				},
+			},
+			gbReqs: []GBRequest{
+				{
+					Path: "/datasets/app.durations",
+					Body: `{"id":"app.durations","fields":{"app":{"type":"string","name":"App"},"build_runtime":{"type":"duration","name":"Build runtime","time_unit":"minutes"}}}`,
+				},
+				{
+					Path: "/datasets/app.durations/data",
+					Body: `{"data":[{"app":"","build_runtime":0.12349876543},{"app":"","build_runtime":46.432763287},{"app":"everdeen","build_runtime":0.31882276212},{"app":"everdeen","build_runtime":144.31838122382},{"app":"geckoboard-ruby","build_runtime":0.21882232124},{"app":"geckoboard-ruby","build_runtime":77.21381276421},{"app":"geckoboard-ruby","build_runtime":0},{"app":"react","build_runtime":118.18382961212},{"app":"westworld","build_runtime":321.93774373}]}`,
+				},
+			},
+		},
+		{
 			// Replace update type sends the first batch only
 			config: models.Config{
 				DatabaseConfig: &models.DatabaseConfig{

--- a/models/dataset.go
+++ b/models/dataset.go
@@ -19,6 +19,7 @@ const (
 	MoneyType      FieldType = "money"
 	PercentageType FieldType = "percentage"
 	StringType     FieldType = "string"
+	DurationType   FieldType = "duration"
 )
 
 var (
@@ -33,6 +34,7 @@ var fieldTypes = []FieldType{
 	MoneyType,
 	PercentageType,
 	StringType,
+	DurationType,
 }
 
 type Dataset struct {
@@ -49,6 +51,7 @@ type Field struct {
 	Key          string    `json:"-"                        yaml:"key"`
 	Name         string    `json:"name"                     yaml:"name"`
 	CurrencyCode string    `json:"currency_code,omitempty"  yaml:"currency_code"`
+	TimeUnit     string    `json:"time_unit,omitempty"      yaml:"time_unit"`
 	Optional     bool      `json:"optional,omitempty"       yaml:"optional,omitempty"`
 }
 
@@ -187,6 +190,10 @@ func (f Field) Validate() (errors []string) {
 
 	if f.Type == MoneyType && f.CurrencyCode == "" {
 		errors = append(errors, errMissingCurrency)
+	}
+
+	if f.Type == DurationType && f.TimeUnit == "" {
+		errors = append(errors, errMissingTimeUnit)
 	}
 
 	return errors

--- a/models/dataset_test.go
+++ b/models/dataset_test.go
@@ -469,6 +469,24 @@ func TestDatasetValidate(t *testing.T) {
 				Name:       "app.build.cost",
 				UpdateType: Replace,
 				SQL:        "SELECT * FROM some_funky_table;",
+				Fields:     []Field{{Name: "duration", Type: DurationType}},
+			},
+			[]string{errMissingTimeUnit},
+		},
+		{
+			Dataset{
+				Name:       "app.build.cost",
+				UpdateType: Replace,
+				SQL:        "SELECT * FROM some_funky_table;",
+				Fields:     []Field{{Name: "duration", Type: DurationType, TimeUnit: "milliseconds"}},
+			},
+			nil,
+		},
+		{
+			Dataset{
+				Name:       "app.build.cost",
+				UpdateType: Replace,
+				SQL:        "SELECT * FROM some_funky_table;",
 				Fields:     []Field{{Name: "count", Type: MoneyType, CurrencyCode: "USD"}},
 			},
 			nil,

--- a/models/errors.go
+++ b/models/errors.go
@@ -39,6 +39,9 @@ const (
 	errMissingCurrency = "No currency_code provided for the money field %s. " +
 		"Please provide an ISO4217 currency code."
 
+	errMissingTimeUnit = "No time_unit provided for the duration field %s. " +
+		"Please provide one of milliseconds, seconds, minutes or hours"
+
 	errDuplicateFieldNames = `The field names "%s" will create duplicate keys. ` +
 		`Please revise using a unique combination of letters and numbers.`
 )

--- a/models/sql.go
+++ b/models/sql.go
@@ -37,7 +37,7 @@ func (ds Dataset) BuildDataset(dc *DatabaseConfig, db *sql.DB) (DatasetRows, err
 			k := f.KeyValue()
 
 			switch f.Type {
-			case NumberType, MoneyType, PercentageType:
+			case NumberType, MoneyType, PercentageType, DurationType:
 				data[k] = col.(*Number).Value(f.Optional)
 			case StringType:
 				data[k] = col.(*null.String).String
@@ -97,7 +97,7 @@ func (ds Dataset) queryDatasource(dc *DatabaseConfig, db *sql.DB) (records []int
 
 func (f Field) fieldTypeMapping() interface{} {
 	switch f.Type {
-	case NumberType, MoneyType, PercentageType:
+	case NumberType, MoneyType, PercentageType, DurationType:
 		var x Number
 		return &x
 	case StringType:


### PR DESCRIPTION
Adds support for the duration type on [datasets API](https://developer.geckoboard.com/?shell#duration-format).. 
As with other types it leaves the query writer to CAST to the relevant type as required. 

So for postgresql interval for example they'd will need to extract and cast for example, example below with an interval with minutes and seconds example.

```sql
    SELECT status, EXTRACT(seconds FROM finished_at - created_at) + EXTRACT(minutes FROM finished_at - created_at)*60
    FROM schedule_run
```

![image](https://user-images.githubusercontent.com/4930249/129734549-8567a4c5-e78e-4325-bf63-510ee018ec35.png)

![image](https://user-images.githubusercontent.com/4930249/129733819-e5ba80ad-f2aa-4566-81b1-8e1c9e7629a4.png)